### PR TITLE
Update to enroll.cpp/identify.cpp/verify.cpp to make fprint work on Raspbian Jessie with Node Js 4.4.3

### DIFF
--- a/src/enroll.cpp
+++ b/src/enroll.cpp
@@ -47,7 +47,7 @@ void report_enroll_stopped(uv_async_t *handle, int status)
 #endif
 {
     ENROLL_STOP *data = container_of(handle, ENROLL_STOP, async);
-    Nan::HandleScope();
+    Nan::HandleScope scope;
 
     if(!data)
         return;
@@ -112,7 +112,7 @@ void report_enroll_progress(uv_async_t *handle, int status)
 #endif
 {
     ENROLL_DATA *enrollData = container_of(handle, ENROLL_DATA, async);
-    Nan::HandleScope();
+    Nan::HandleScope scope;
 
     if(!enrollData)
         return;

--- a/src/identify.cpp
+++ b/src/identify.cpp
@@ -46,7 +46,7 @@ void report_identify_stop(uv_async_t *handle, int status)
 #endif
 {
     IDENTIFY_STOP *data = container_of(handle, IDENTIFY_STOP, async);
-    Nan::HandleScope();
+    Nan::HandleScope scope;
 
     if(!data)
         return;
@@ -113,7 +113,7 @@ void report_identify_start(uv_async_t *handle, int status)
 #endif
 {
     IDENTIFY_START *data = container_of(handle, IDENTIFY_START, async);
-    Nan::HandleScope();
+    Nan::HandleScope scope;
 
     if(!data)
         return;

--- a/src/verify.cpp
+++ b/src/verify.cpp
@@ -45,7 +45,7 @@ void report_verify_stop(uv_async_t *handle, int status)
 #endif
 {
     VERIFY_STOP *data = container_of(handle, VERIFY_STOP, async);
-    Nan::HandleScope();
+    Nan::HandleScope scope;
 
     if(!data)
         return;
@@ -106,7 +106,7 @@ void report_verify_start(uv_async_t *handle, int status)
 #endif
 {
     VERIFY_START *data = container_of(handle, VERIFY_START, async);
-    Nan::HandleScope();
+    Nan::HandleScope scope;
 
     if(!data)
         return;


### PR DESCRIPTION
Encountered an error while trying to run fprint on a Raspberry Pi 2 running Raspbian Jessie with Node Js 4.4.3.

`FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope`

The error disappeared when replacing `Nan::HandleScope();` with `Nan::HandleScope scope;`. 
Hence the changes in this pull request.

Cheers,

Marcel
