### PR TITLE
Enroll fix

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,7 @@
 			],
 			"libraries": [
 				"<!(pkg-config --libs libfprint)",
-				"<!(pkg-config --cflags zlib)"
+				"<!(pkg-config --libs-only-l zlib)"
 			],
 			"variables": {
 				"node_version": '<!(node --version | sed -e "s/^v\([0-9]*\\.[0-9]*\).*$/\\1/")',

--- a/src/enroll.cpp
+++ b/src/enroll.cpp
@@ -146,7 +146,12 @@ static void enroll_stage_cb(struct fp_dev *dev, int result, struct fp_print_data
 {
     ENROLL_DATA *enrollData = (ENROLL_DATA*)user_data;
 
-    if(!enrollData || result < 0)
+	// result will return -number for anything that caused the device to fail to 
+	// Initialize, -1 appears to be a valid result that can be safely ignored
+	// Example: the UV4000, if unable to power up properly; will return a -110 (ETIMEOUT) here.
+	// Device then is then totally unusable, and their are no additional errors presented after
+	// this point, so we have to catch it here and let the error through.
+    if(!enrollData || result == -1)
         return;
 
     enrollData->result = result;


### PR DESCRIPTION
Sorry, I picked up Alan's node.gyp changes because I based my changes on his repo.   

My change deals with the device driver returning error messages as the first result; and the enroll code was set to eat the error and not do anything with it.   The issue is that in the UV4000 case, the device could time out trying to power up three times and then because the enroll code would eat the -110 error; the code would be dead as the device never powered up and I had no way to know the status.  So I changed the code to let the -1 (which appears to be a valid result) be eaten, but all other negative numbers will be propagated back so that the end client can decide what to do...    My change is trivial; once you trace down what the issue is -- so feel free to just copy the code and close the pull request.
